### PR TITLE
fix: webinar landing page styling per design feedback

### DIFF
--- a/i-need-customers-1/index.html
+++ b/i-need-customers-1/index.html
@@ -33,7 +33,7 @@
           to request a seat for the live session on Wednesday, 15 July 2026 at
           11:00 AM GST.
         </p>
-        <div class="wf-panel_footer">
+        <div class="wf-panel_footer -hide-mobile">
           <div class="wf-qr">
             <img
               src="/themes/homesociete/dist/images/webinar-qr.png"
@@ -260,6 +260,43 @@
             Apply For A Vetted Seat
           </button>
         </form>
+
+        <div class="wf-panel_footer -show-mobile">
+          <div class="wf-qr">
+            <img
+              src="/themes/homesociete/dist/images/webinar-qr.png"
+              alt="Scan to visit edgidesignhub.com"
+              width="96"
+              height="96"
+            />
+            <p>Scan QR code<br />to visit website</p>
+          </div>
+          <div class="wf-socials">
+            <p>Please Follow Us</p>
+            <div class="wf-socials_icons">
+              <a
+                href="https://www.instagram.com/edgidesignhub?igsh=MWRtNG9wcjU2M2VyNA=="
+                target="_blank"
+                rel="noopener"
+                ><img
+                  src="/themes/homesociete/dist/images/webinar-instagram.png"
+                  alt="Instagram"
+                  width="32"
+                  height="32"
+              /></a>
+              <a
+                href="https://www.linkedin.com/company/edgi-design-hub-edh/"
+                target="_blank"
+                rel="noopener"
+                ><img
+                  src="/themes/homesociete/dist/images/webinar-linkedin.png"
+                  alt="LinkedIn"
+                  width="32"
+                  height="32"
+              /></a>
+            </div>
+          </div>
+        </div>
       </main>
     </div>
     <script src="/themes/homesociete/dist/scripts/webinar-form.js"></script>

--- a/i-need-customers-2/index.html
+++ b/i-need-customers-2/index.html
@@ -36,7 +36,7 @@
           responses and confirm 5 slots where I feel I can add the most
           practical value.
         </p>
-        <div class="wf-panel_footer">
+        <div class="wf-panel_footer -hide-mobile">
           <div class="wf-qr">
             <img
               src="/themes/homesociete/dist/images/webinar-qr.png"
@@ -883,6 +883,43 @@
             Apply for a Brand Clarity Call
           </button>
         </form>
+
+        <div class="wf-panel_footer -show-mobile">
+          <div class="wf-qr">
+            <img
+              src="/themes/homesociete/dist/images/webinar-qr.png"
+              alt="Scan to visit edgidesignhub.com"
+              width="96"
+              height="96"
+            />
+            <p>Scan QR code<br />to visit website</p>
+          </div>
+          <div class="wf-socials">
+            <p>Please Follow Us</p>
+            <div class="wf-socials_icons">
+              <a
+                href="https://www.instagram.com/edgidesignhub?igsh=MWRtNG9wcjU2M2VyNA=="
+                target="_blank"
+                rel="noopener"
+                ><img
+                  src="/themes/homesociete/dist/images/webinar-instagram.png"
+                  alt="Instagram"
+                  width="32"
+                  height="32"
+              /></a>
+              <a
+                href="https://www.linkedin.com/company/edgi-design-hub-edh/"
+                target="_blank"
+                rel="noopener"
+                ><img
+                  src="/themes/homesociete/dist/images/webinar-linkedin.png"
+                  alt="LinkedIn"
+                  width="32"
+                  height="32"
+              /></a>
+            </div>
+          </div>
+        </div>
       </main>
     </div>
     <script src="/themes/homesociete/dist/scripts/webinar-form.js"></script>

--- a/themes/homesociete/dist/styles/webinar.css
+++ b/themes/homesociete/dist/styles/webinar.css
@@ -14,7 +14,7 @@
 .wf-panel {
   background-color: #f6f6f6;
   padding: 2.5rem 1.5rem;
-  text-align: center;
+  text-align: left;
 }
 
 .wf-logo {
@@ -29,8 +29,9 @@
 
 .wf-headline {
   color: var(--red);
-  font-size: 1.375rem;
-  font-weight: bold;
+  font-family: "Gotham", sans-serif;
+  font-size: 1.5rem;
+  font-weight: normal;
   line-height: 1.3;
   margin: 1.5rem 0 0.5rem;
 }
@@ -45,15 +46,25 @@
   margin-top: 2rem;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
   gap: 1.25rem;
+}
+
+.wf-panel_footer.-hide-mobile {
+  display: none;
+}
+
+.wf-panel_footer.-show-mobile {
+  display: flex;
+  max-width: 30rem;
+  margin: 2.5rem auto 0;
 }
 
 .wf-qr img {
   display: block;
   width: 96px;
   height: 96px;
-  margin: 0 auto 0.5rem;
+  margin: 0 0 0.5rem;
 }
 
 .wf-qr p {
@@ -66,7 +77,7 @@
 .wf-socials {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
 }
 
 .wf-socials p {
@@ -77,7 +88,11 @@
 
 .wf-socials_icons a {
   display: inline-block;
-  margin: 0 0.375rem;
+  margin: 0 0.75rem 0 0;
+}
+
+.wf-socials_icons a:last-child {
+  margin-right: 0;
 }
 
 .wf-socials_icons img {
@@ -103,7 +118,9 @@
 
 .wf-thankyou h1 {
   color: var(--red);
+  font-family: "Gotham", sans-serif;
   font-size: 1.5rem;
+  font-weight: normal;
   margin: 0 0 1.25rem;
 }
 
@@ -127,7 +144,7 @@ fieldset.wf-field {
   width: 100%;
   box-sizing: border-box;
   padding: 0.9375rem;
-  border-radius: 4px;
+  border-radius: 0;
   font-family: inherit;
   font-size: 0.875rem;
 }
@@ -138,8 +155,9 @@ textarea.wf-input {
 }
 
 .wf-question {
-  font-size: 0.9375rem;
-  font-weight: bold;
+  color: var(--black);
+  font-size: 1.0625rem;
+  font-weight: normal;
   margin: 0 0 0.625rem;
 }
 
@@ -187,8 +205,13 @@ textarea.wf-input {
 .wf-submit {
   display: block;
   width: 100%;
+  box-sizing: border-box;
+  padding: 0.9375rem;
   text-align: center;
-  border-radius: 20px;
+  border: 1px solid var(--black);
+  border-radius: 0;
+  background-color: #fff;
+  color: var(--black);
   cursor: pointer;
   font-size: 0.9375rem;
 }
@@ -205,6 +228,14 @@ textarea.wf-input {
 }
 
 @media (min-width: 900px) {
+  .wf-panel_footer.-hide-mobile {
+    display: flex;
+  }
+
+  .wf-panel_footer.-show-mobile {
+    display: none;
+  }
+
   .wf-shell {
     flex-direction: row;
   }


### PR DESCRIPTION
## Summary
- Remove border-radius from form fields and submit button
- Fix red titles to use Gotham font (was inheriting `GT Super Display` from main.css's global `h1` rule)
- Restyle submit button to match the homepage contact-form button (0 border-radius, white background, black border)
- Left-align all text in the sidebar panel/footer (was center-aligned)
- Show the QR/social block after the form on mobile, keep it in the sticky sidebar on desktop
- Remove bold font weight everywhere; emphasis now comes from color/size instead

## Test plan
- [x] Verified both form pages (i-need-customers-1, i-need-customers-2) and both thank-you pages at mobile (390px) and desktop (1440px) widths via Playwright screenshots
- [x] Confirmed square corners on inputs/submit button, Gotham font on titles, left-aligned text, and correct QR/social placement per breakpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)