### PR TITLE
fix: move QR/social block below thank-you message content

### DIFF
--- a/thank-you-1/index.html
+++ b/thank-you-1/index.html
@@ -28,42 +28,6 @@
             ></use>
           </svg>
         </a>
-        <div class="wf-panel_footer">
-          <div class="wf-qr">
-            <img
-              src="/themes/homesociete/dist/images/webinar-qr.png"
-              alt="Scan to visit edgidesignhub.com"
-              width="96"
-              height="96"
-            />
-            <p>Scan QR code<br />to visit website</p>
-          </div>
-          <div class="wf-socials">
-            <p>Please Follow Us</p>
-            <div class="wf-socials_icons">
-              <a
-                href="https://www.instagram.com/edgidesignhub?igsh=MWRtNG9wcjU2M2VyNA=="
-                target="_blank"
-                rel="noopener"
-                ><img
-                  src="/themes/homesociete/dist/images/webinar-instagram.png"
-                  alt="Instagram"
-                  width="32"
-                  height="32"
-              /></a>
-              <a
-                href="https://www.linkedin.com/company/edgi-design-hub-edh/"
-                target="_blank"
-                rel="noopener"
-                ><img
-                  src="/themes/homesociete/dist/images/webinar-linkedin.png"
-                  alt="LinkedIn"
-                  width="32"
-                  height="32"
-              /></a>
-            </div>
-          </div>
-        </div>
       </aside>
       <main class="wf-form_panel -center">
         <div class="wf-thankyou">
@@ -88,6 +52,43 @@
             In the meantime, ask yourself one honest question:<br />
             Is my current brand helping customers choose me faster?
           </p>
+
+          <div class="wf-panel_footer">
+            <div class="wf-qr">
+              <img
+                src="/themes/homesociete/dist/images/webinar-qr.png"
+                alt="Scan to visit edgidesignhub.com"
+                width="96"
+                height="96"
+              />
+              <p>Scan QR code<br />to visit website</p>
+            </div>
+            <div class="wf-socials">
+              <p>Please Follow Us</p>
+              <div class="wf-socials_icons">
+                <a
+                  href="https://www.instagram.com/edgidesignhub?igsh=MWRtNG9wcjU2M2VyNA=="
+                  target="_blank"
+                  rel="noopener"
+                  ><img
+                    src="/themes/homesociete/dist/images/webinar-instagram.png"
+                    alt="Instagram"
+                    width="32"
+                    height="32"
+                /></a>
+                <a
+                  href="https://www.linkedin.com/company/edgi-design-hub-edh/"
+                  target="_blank"
+                  rel="noopener"
+                  ><img
+                    src="/themes/homesociete/dist/images/webinar-linkedin.png"
+                    alt="LinkedIn"
+                    width="32"
+                    height="32"
+                /></a>
+              </div>
+            </div>
+          </div>
         </div>
       </main>
     </div>

--- a/thank-you-2/index.html
+++ b/thank-you-2/index.html
@@ -28,42 +28,6 @@
             ></use>
           </svg>
         </a>
-        <div class="wf-panel_footer">
-          <div class="wf-qr">
-            <img
-              src="/themes/homesociete/dist/images/webinar-qr.png"
-              alt="Scan to visit edgidesignhub.com"
-              width="96"
-              height="96"
-            />
-            <p>Scan QR code<br />to visit website</p>
-          </div>
-          <div class="wf-socials">
-            <p>Please Follow Us</p>
-            <div class="wf-socials_icons">
-              <a
-                href="https://www.instagram.com/edgidesignhub?igsh=MWRtNG9wcjU2M2VyNA=="
-                target="_blank"
-                rel="noopener"
-                ><img
-                  src="/themes/homesociete/dist/images/webinar-instagram.png"
-                  alt="Instagram"
-                  width="32"
-                  height="32"
-              /></a>
-              <a
-                href="https://www.linkedin.com/company/edgi-design-hub-edh/"
-                target="_blank"
-                rel="noopener"
-                ><img
-                  src="/themes/homesociete/dist/images/webinar-linkedin.png"
-                  alt="LinkedIn"
-                  width="32"
-                  height="32"
-              /></a>
-            </div>
-          </div>
-        </div>
       </aside>
       <main class="wf-form_panel -center">
         <div class="wf-thankyou">
@@ -80,6 +44,43 @@
             In the meantime, take one honest look at your business and ask:<br />
             Is my brand helping customers choose me faster?
           </p>
+
+          <div class="wf-panel_footer">
+            <div class="wf-qr">
+              <img
+                src="/themes/homesociete/dist/images/webinar-qr.png"
+                alt="Scan to visit edgidesignhub.com"
+                width="96"
+                height="96"
+              />
+              <p>Scan QR code<br />to visit website</p>
+            </div>
+            <div class="wf-socials">
+              <p>Please Follow Us</p>
+              <div class="wf-socials_icons">
+                <a
+                  href="https://www.instagram.com/edgidesignhub?igsh=MWRtNG9wcjU2M2VyNA=="
+                  target="_blank"
+                  rel="noopener"
+                  ><img
+                    src="/themes/homesociete/dist/images/webinar-instagram.png"
+                    alt="Instagram"
+                    width="32"
+                    height="32"
+                /></a>
+                <a
+                  href="https://www.linkedin.com/company/edgi-design-hub-edh/"
+                  target="_blank"
+                  rel="noopener"
+                  ><img
+                    src="/themes/homesociete/dist/images/webinar-linkedin.png"
+                    alt="LinkedIn"
+                    width="32"
+                    height="32"
+                /></a>
+              </div>
+            </div>
+          </div>
         </div>
       </main>
     </div>


### PR DESCRIPTION
## Summary
- On both thank-you pages, the QR code + social icons block previously lived in the sidebar (above the message on mobile, beside it on desktop). Moved it into the main content flow, directly below the thank-you message, at all breakpoints.
- The sidebar now just holds the logo.

## Test plan
- [x] Verified thank-you-1 and thank-you-2 at mobile (390px) and desktop (1440px) via local screenshots — QR/social renders below the message text, sidebar shows only the logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)