### PR TITLE
feat: add reCAPTCHA v3 to webinar form submissions

### DIFF
--- a/i-need-customers-1/index.html
+++ b/i-need-customers-1/index.html
@@ -76,6 +76,7 @@
           method="POST"
           data-action="https://edgidesignhub.com/api/send-registration"
           data-thankyou="/thank-you-1"
+          data-recaptcha-sitekey="6LfU2kUtAAAAAHoj4_sACpgkzCEcZE3KW7-NEjRe"
         >
           <p class="wf-error" role="alert" hidden></p>
 
@@ -259,6 +260,13 @@
           <button type="submit" class="o-button wf-submit" style="max-width: 60%;">
             Apply For A Vetted Seat
           </button>
+          <p class="wf-recaptcha-note">
+            This site is protected by reCAPTCHA and the Google
+            <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Privacy Policy</a>
+            and
+            <a href="https://policies.google.com/terms" target="_blank" rel="noopener">Terms of Service</a>
+            apply.
+          </p>
         </form>
 
         <div class="wf-panel_footer -show-mobile" style="flex-direction: row;">
@@ -299,6 +307,7 @@
         </div>
       </main>
     </div>
+    <script src="https://www.google.com/recaptcha/api.js?render=6LfU2kUtAAAAAHoj4_sACpgkzCEcZE3KW7-NEjRe" async defer></script>
     <script src="/themes/homesociete/dist/scripts/webinar-form.js"></script>
   </body>
 </html>

--- a/i-need-customers-2/index.html
+++ b/i-need-customers-2/index.html
@@ -79,6 +79,7 @@
           method="POST"
           data-action="https://edgidesignhub.com/api/send-brand-clarity"
           data-thankyou="/thank-you-2"
+          data-recaptcha-sitekey="6LfU2kUtAAAAAHoj4_sACpgkzCEcZE3KW7-NEjRe"
         >
           <p class="wf-error" role="alert" hidden></p>
 
@@ -882,6 +883,13 @@
           <button type="submit" class="o-button wf-submit">
             Apply for a Brand Clarity Call
           </button>
+          <p class="wf-recaptcha-note">
+            This site is protected by reCAPTCHA and the Google
+            <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Privacy Policy</a>
+            and
+            <a href="https://policies.google.com/terms" target="_blank" rel="noopener">Terms of Service</a>
+            apply.
+          </p>
         </form>
 
         <div class="wf-panel_footer -show-mobile" style="flex-direction: row;">
@@ -922,6 +930,7 @@
         </div>
       </main>
     </div>
+    <script src="https://www.google.com/recaptcha/api.js?render=6LfU2kUtAAAAAHoj4_sACpgkzCEcZE3KW7-NEjRe" async defer></script>
     <script src="/themes/homesociete/dist/scripts/webinar-form.js"></script>
   </body>
 </html>

--- a/themes/homesociete/dist/scripts/webinar-form.js
+++ b/themes/homesociete/dist/scripts/webinar-form.js
@@ -93,35 +93,52 @@
       var submitButton = form.querySelector('button[type="submit"]');
       if (submitButton) submitButton.disabled = true;
 
-      var body = new URLSearchParams(new FormData(form));
+      function submitWithToken(token) {
+        var body = new URLSearchParams(new FormData(form));
+        if (token) body.set("g-recaptcha-response", token);
 
-      fetch(form.dataset.action, {
-        method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        body: body,
-      })
-        .then(function (response) {
-          return response.json().then(function (data) {
-            return { ok: response.ok, data: data };
+        fetch(form.dataset.action, {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: body,
+        })
+          .then(function (response) {
+            return response.json().then(function (data) {
+              return { ok: response.ok, data: data };
+            });
+          })
+          .then(function (result) {
+            if (result.ok && result.data && result.data.success) {
+              window.location.href = form.dataset.thankyou;
+            } else {
+              throw new Error(
+                (result.data && result.data.error) || "Something went wrong"
+              );
+            }
+          })
+          .catch(function () {
+            if (errorEl) {
+              errorEl.hidden = false;
+              errorEl.textContent =
+                "Something went wrong submitting your application. Please try again in a moment.";
+            }
+            if (submitButton) submitButton.disabled = false;
           });
-        })
-        .then(function (result) {
-          if (result.ok && result.data && result.data.success) {
-            window.location.href = form.dataset.thankyou;
-          } else {
-            throw new Error(
-              (result.data && result.data.error) || "Something went wrong"
-            );
-          }
-        })
-        .catch(function () {
-          if (errorEl) {
-            errorEl.hidden = false;
-            errorEl.textContent =
-              "Something went wrong submitting your application. Please try again in a moment.";
-          }
-          if (submitButton) submitButton.disabled = false;
+      }
+
+      var siteKey = form.dataset.recaptchaSitekey;
+      if (siteKey && window.grecaptcha) {
+        grecaptcha.ready(function () {
+          grecaptcha
+            .execute(siteKey, { action: "webinar_form_submit" })
+            .then(submitWithToken)
+            .catch(function () {
+              submitWithToken(null);
+            });
         });
+      } else {
+        submitWithToken(null);
+      }
     });
   }
 

--- a/themes/homesociete/dist/styles/webinar.css
+++ b/themes/homesociete/dist/styles/webinar.css
@@ -221,6 +221,24 @@ textarea.wf-input {
   cursor: default;
 }
 
+/* reCAPTCHA v3 runs invisibly; the floating badge is hidden per Google's
+   terms, which requires showing this attribution text instead. */
+.grecaptcha-badge {
+  visibility: hidden;
+}
+
+.wf-recaptcha-note {
+  font-size: 0.75rem;
+  color: var(--grey);
+  line-height: 1.4;
+  margin: 0.75rem 0 0;
+}
+
+.wf-recaptcha-note a {
+  color: inherit;
+  text-decoration: underline;
+}
+
 .wf-error {
   color: #c81616;
   font-size: 0.875rem;


### PR DESCRIPTION
## Summary
- Load Google reCAPTCHA v3 (invisible) on both webinar forms using site key `6LfU2kUtAAAAAHoj4_sACpgkzCEcZE3KW7-NEjRe`
- Generate a token on submit (`grecaptcha.execute`) and attach it as `g-recaptcha-response` in the POST body; server-side verification is in a separate production-only change to `node_service/server.js`
- Hide the default floating badge and show the required Google attribution text near the submit button instead
- Fall back to submitting without a token if the reCAPTCHA script fails to load, so the form isn't hard-blocked client-side (the server enforces the real check)

## Test plan
- [x] Verified both forms render correctly locally (badge hidden, disclosure text present, no console errors, `grecaptcha` loads)
- [ ] End-to-end live test against production once deployed (real token generation requires the registered domain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)